### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.5.0 (2024-09-17)
+* change the forked `curve25519-dalek` dependency back to the original repo.
+* remove features `std`, `simd_backend` and `nightly`. Please check `curve25519-dalek` [README.md](https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek#simd-backend) for adding SIMD support.
+* enable feature `zeroize` in `curve25519-dalek` dependency.
+
 ### 0.4.0 (2021-01-29)
 * replace `curve25519-dalek` dependency with a fork
 * bump `curve25519-dalek` to version 4, removing the need for the `util` module (as `curve25519-dalek` now uses `rand-core` 0.6)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-elgamal"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Eleanor McMurtry <elem0@protonmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,18 +12,13 @@ keywords = ["cryptography", "crypto", "ristretto", "ristretto255", "elgamal"]
 description = "A straightforward implementation of ElGamal homomorphic encryption using the ristretto255 elliptic curve group."
 
 [features]
-nightly = ["curve25519-dalek/nightly"]
-default = ["std"]
 # cannot call the feature "serde" (yet)
 enable-serde = ["serde", "curve25519-dalek/serde"]
-simd_backend = ["nightly", "curve25519-dalek/simd_backend"]
-std = ["curve25519-dalek/std", "rand_core/std", "serde/std"]
 
 [dependencies]
-# simd_backend extends u64_backend
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default_features = false, features = ["alloc", "u64_backend"] }
-rand_core = { version = "0.6", default_features = false }
-serde = { version = "1", default_features = false, features = ["derive"], optional = true }
+curve25519-dalek = { package = "curve25519-dalek", version = "4", features = ["alloc", "rand_core", "precomputed-tables", "zeroize"] }
+rand_core = { version = "0.6" }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 bincode = "1"

--- a/README.md
+++ b/README.md
@@ -29,20 +29,11 @@ let mut rng = StdRng::from_entropy();
 let dec_key = DecryptionKey::new(&mut rng);
 let enc_key = dec_key.encryption_key();
 
-let message = &Scalar::from(5u32) * &GENERATOR_TABLE;
+let message = &Scalar::from(5u32) * GENERATOR_TABLE;
 let encrypted = enc_key.encrypt(message, &mut rng);
 let decrypted = dec_key.decrypt(encrypted);
 assert_eq!(message, decrypted);
 ```
 
 ## Features
-* `std` (enabled by default): include the Rust standard library. Disable this feature for embedded environments.
 * `enable-serde`: Turn on [serde](https://docs.rs/serde/) support.
-* `simd_backend`: This crate uses [curve25519-dalek](https://docs.rs/curve25519-dalek/3.0.2/curve25519_dalek/) to implement elliptic curve group operations. With nightly Rust, curve25519-dalek supports SIMD (single-instruction, multiple-data) instructions for extra efficiency. Enable this feature with a nightly version of Rust to use SIMD operations (either `avx2` or `ifma`). For example: 
-```bash
-# Requires nightly, RUSTFLAGS="-C target_feature=+avx2" to use avx2
-cargo build --features "simd_backend"
-# Requires nightly, RUSTFLAGS="-C target_feature=+avx512ifma" to use ifma
-cargo build --features "simd_backend"
-```
-* `nightly`: used for building documentation and for SIMD support.

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -13,16 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::fmt::{Formatter, Debug};
+use core::fmt::{Debug, Formatter};
 
-use curve25519_dalek::constants::{RISTRETTO_BASEPOINT_TABLE, RISTRETTO_BASEPOINT_POINT};
+use curve25519_dalek::constants::{RISTRETTO_BASEPOINT_POINT, RISTRETTO_BASEPOINT_TABLE};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
-use rand_core::{RngCore, CryptoRng};
+use rand_core::{CryptoRng, RngCore};
 
 #[cfg(feature = "enable-serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::{Ciphertext, DecryptionKey};
 
@@ -79,7 +79,7 @@ impl EncryptionKey {
     /// let encrypted = enc_key.exp_encrypt_with(m, r);
     /// ```
     pub fn exp_encrypt_with(&self, m: Scalar, r: Scalar) -> Ciphertext {
-        let c1 = &r * &RISTRETTO_BASEPOINT_TABLE;
+        let c1 = &r * RISTRETTO_BASEPOINT_TABLE;
         // mG + rY
         let c2 = RistrettoPoint::multiscalar_mul(&[m, r], &[RISTRETTO_BASEPOINT_POINT, self.0]);
         Ciphertext(c1, c2)
@@ -98,7 +98,7 @@ impl EncryptionKey {
     /// let dec_key = DecryptionKey::new(&mut rng);
     /// let enc_key = dec_key.encryption_key();
     ///
-    /// let m = &Scalar::from(5u32) * &GENERATOR_TABLE;
+    /// let m = &Scalar::from(5u32) * GENERATOR_TABLE;
     /// let encrypted = enc_key.encrypt(m, &mut rng);
     /// ```
     pub fn encrypt<R: RngCore + CryptoRng>(&self, m: RistrettoPoint, rng: &mut R) -> Ciphertext {
@@ -118,12 +118,12 @@ impl EncryptionKey {
     /// let dec_key = DecryptionKey::new(&mut rng);
     /// let enc_key = dec_key.encryption_key();
     ///
-    /// let m = &Scalar::from(5u32) * &GENERATOR_TABLE;
+    /// let m = &Scalar::from(5u32) * GENERATOR_TABLE;
     /// let r = Scalar::from(10u32);
     /// let encrypted = enc_key.encrypt_with(m, r);
     /// ```
     pub fn encrypt_with(&self, m: RistrettoPoint, r: Scalar) -> Ciphertext {
-        let c1 = &r * &RISTRETTO_BASEPOINT_TABLE;
+        let c1 = &r * RISTRETTO_BASEPOINT_TABLE;
         let c2 = m + r * &self.0;
         Ciphertext(c1, c2)
     }
@@ -142,7 +142,7 @@ impl EncryptionKey {
     /// let dec_key = DecryptionKey::new(&mut rng);
     /// let enc_key = dec_key.encryption_key();
     ///
-    /// let m = &Scalar::from(5u32) * &GENERATOR_TABLE;
+    /// let m = &Scalar::from(5u32) * GENERATOR_TABLE;
     /// let ct1 = enc_key.encrypt(m, &mut rng);
     /// let ct2 = enc_key.rerandomise(ct1, &mut rng);
     /// assert_eq!(dec_key.decrypt(ct1), dec_key.decrypt(ct2));
@@ -151,7 +151,6 @@ impl EncryptionKey {
     pub fn rerandomise<R: RngCore + CryptoRng>(&self, ct: Ciphertext, rng: &mut R) -> Ciphertext {
         self.rerandomise_with(ct, Scalar::random(rng))
     }
-
 
     /// Re-randomise the ciphertext `ct` with the provided blinding factor.
     /// This will generate a new encryption of the same curve point.
@@ -167,7 +166,7 @@ impl EncryptionKey {
     /// let dec_key = DecryptionKey::new(&mut rng);
     /// let enc_key = dec_key.encryption_key();
     ///
-    /// let m = &Scalar::from(5u32) * &GENERATOR_TABLE;
+    /// let m = &Scalar::from(5u32) * GENERATOR_TABLE;
     /// let ct1 = enc_key.encrypt(m, &mut rng);
     ///
     /// let r = Scalar::from(10u32);
@@ -177,7 +176,7 @@ impl EncryptionKey {
     /// ```
     #[must_use = "the Ciphertext input is not mutated, the function returns the new rerandomised Ciphertext"]
     pub fn rerandomise_with(&self, ct: Ciphertext, r: Scalar) -> Ciphertext {
-        let c1 = ct.0 + &r * &RISTRETTO_BASEPOINT_TABLE;
+        let c1 = ct.0 + &r * RISTRETTO_BASEPOINT_TABLE;
         let c2 = ct.1 + &self.0 * r;
         Ciphertext(c1, c2)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,20 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_std]
-#![cfg_attr(feature = "nightly", feature(external_doc))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-
 mod ciphertext;
 mod decrypt;
 mod encrypt;
 
-use curve25519_dalek::constants::{RISTRETTO_BASEPOINT_POINT, RISTRETTO_BASEPOINT_TABLE, RISTRETTO_BASEPOINT_COMPRESSED};
+use curve25519_dalek::constants::{
+    RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT, RISTRETTO_BASEPOINT_TABLE,
+};
 use curve25519_dalek::ristretto::RistrettoBasepointTable;
 
-pub use curve25519_dalek::scalar::Scalar;
-pub use curve25519_dalek::ristretto::RistrettoPoint;
 pub use curve25519_dalek::ristretto::CompressedRistretto;
+pub use curve25519_dalek::ristretto::RistrettoPoint;
+pub use curve25519_dalek::scalar::Scalar;
 
 pub use curve25519_dalek::traits::Identity;
 pub use curve25519_dalek::traits::IsIdentity;
@@ -48,7 +46,7 @@ pub const GENERATOR_POINT_COMPRESSED: CompressedRistretto = RISTRETTO_BASEPOINT_
 
 /// The group generator as a table of precomputed multiples. This is the most efficient way to
 /// produce a scalar multiple of the generator.
-pub const GENERATOR_TABLE: RistrettoBasepointTable = RISTRETTO_BASEPOINT_TABLE;
+pub static GENERATOR_TABLE: &RistrettoBasepointTable = RISTRETTO_BASEPOINT_TABLE;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
* change the forked `curve25519-dalek` dependency back to the original repo.
* remove features `std`, `simd_backend` and `nightly`. 
* enable feature `zeroize` in `curve25519-dalek` dependency.